### PR TITLE
fix: update undici to 7.24.4 via miniflare/wrangler upgrade

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -501,9 +501,9 @@
 			}
 		},
 		"node_modules/@cloudflare/workerd-darwin-64": {
-			"version": "1.20260302.0",
-			"resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-64/-/workerd-darwin-64-1.20260302.0.tgz",
-			"integrity": "sha512-cGtxPByeVrgoqxbmd8qs631wuGwf8yTm/FY44dEW4HdoXrb5jhlE4oWYHFafedkQCvGjY1Vbs3puAiKnuMxTXQ==",
+			"version": "1.20260317.1",
+			"resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-64/-/workerd-darwin-64-1.20260317.1.tgz",
+			"integrity": "sha512-8hjh3sPMwY8M/zedq3/sXoA2Q4BedlGufn3KOOleIG+5a4ReQKLlUah140D7J6zlKmYZAFMJ4tWC7hCuI/s79g==",
 			"cpu": [
 				"x64"
 			],
@@ -518,9 +518,9 @@
 			}
 		},
 		"node_modules/@cloudflare/workerd-darwin-arm64": {
-			"version": "1.20260302.0",
-			"resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-arm64/-/workerd-darwin-arm64-1.20260302.0.tgz",
-			"integrity": "sha512-WRGqV6RNXM3xoQblJJw1EHKwx9exyhB18cdnToSCUFPObFhk3fzMLoQh7S+nUHUpto6aUrXPVj6R/4G3UPjCxw==",
+			"version": "1.20260317.1",
+			"resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-arm64/-/workerd-darwin-arm64-1.20260317.1.tgz",
+			"integrity": "sha512-M/MnNyvO5HMgoIdr3QHjdCj2T1ki9gt0vIUnxYxBu9ISXS/jgtMl6chUVPJ7zHYBn9MyYr8ByeN6frjYxj0MGg==",
 			"cpu": [
 				"arm64"
 			],
@@ -535,9 +535,9 @@
 			}
 		},
 		"node_modules/@cloudflare/workerd-linux-64": {
-			"version": "1.20260302.0",
-			"resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-64/-/workerd-linux-64-1.20260302.0.tgz",
-			"integrity": "sha512-gG423mtUjrmlQT+W2+KisLc6qcGcBLR+QcK5x1gje3bu/dF3oNiYuqY7o58A+sQk6IB849UC4UyNclo1RhP2xw==",
+			"version": "1.20260317.1",
+			"resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-64/-/workerd-linux-64-1.20260317.1.tgz",
+			"integrity": "sha512-1ltuEjkRcS3fsVF7CxsKlWiRmzq2ZqMfqDN0qUOgbUwkpXsLVJsXmoblaLf5OP00ELlcgF0QsN0p2xPEua4Uug==",
 			"cpu": [
 				"x64"
 			],
@@ -552,9 +552,9 @@
 			}
 		},
 		"node_modules/@cloudflare/workerd-linux-arm64": {
-			"version": "1.20260302.0",
-			"resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-arm64/-/workerd-linux-arm64-1.20260302.0.tgz",
-			"integrity": "sha512-7M25noGI4WlSBOhrIaY8xZrnn87OQKtJg9YWAO2EFqGjF1Su5QXGaLlQVF4fAKbqTywbHnI8BAuIsIlUSNkhCg==",
+			"version": "1.20260317.1",
+			"resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-arm64/-/workerd-linux-arm64-1.20260317.1.tgz",
+			"integrity": "sha512-3QrNnPF1xlaNwkHpasvRvAMidOvQs2NhXQmALJrEfpIJ/IDL2la8g499yXp3eqhG3hVMCB07XVY149GTs42Xtw==",
 			"cpu": [
 				"arm64"
 			],
@@ -569,9 +569,9 @@
 			}
 		},
 		"node_modules/@cloudflare/workerd-windows-64": {
-			"version": "1.20260302.0",
-			"resolved": "https://registry.npmjs.org/@cloudflare/workerd-windows-64/-/workerd-windows-64-1.20260302.0.tgz",
-			"integrity": "sha512-jK1L3ADkiWxFzlqZTq2iHW1Bd2Nzu1fmMWCGZw4sMZ2W1B2WCm2wHwO2SX/py4BgylyEN3wuF+5zagbkNKht9A==",
+			"version": "1.20260317.1",
+			"resolved": "https://registry.npmjs.org/@cloudflare/workerd-windows-64/-/workerd-windows-64-1.20260317.1.tgz",
+			"integrity": "sha512-MfZTz+7LfuIpMGTa3RLXHX8Z/pnycZLItn94WRdHr8LPVet+C5/1Nzei399w/jr3+kzT4pDKk26JF/tlI5elpQ==",
 			"cpu": [
 				"x64"
 			],
@@ -3186,16 +3186,16 @@
 			"license": "MIT"
 		},
 		"node_modules/miniflare": {
-			"version": "4.20260302.0",
-			"resolved": "https://registry.npmjs.org/miniflare/-/miniflare-4.20260302.0.tgz",
-			"integrity": "sha512-joGFywlo7HdfHXXGOkc6tDCVkwjEncM0mwEsMOLWcl+vDVJPj9HRV7JtEa0+lCpNOLdYw7mZNHYe12xz9KtJOw==",
+			"version": "4.20260317.0",
+			"resolved": "https://registry.npmjs.org/miniflare/-/miniflare-4.20260317.0.tgz",
+			"integrity": "sha512-xuwk5Kjv+shi5iUBAdCrRl9IaWSGnTU8WuTQzsUS2GlSDIMCJuu8DiF/d9ExjMXYiQG5ml+k9SVKnMj8cRkq0w==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@cspotcode/source-map-support": "0.8.1",
 				"sharp": "^0.34.5",
-				"undici": "7.18.2",
-				"workerd": "1.20260302.0",
+				"undici": "7.24.4",
+				"workerd": "1.20260317.1",
 				"ws": "8.18.0",
 				"youch": "4.1.0-beta.10"
 			},
@@ -3701,9 +3701,9 @@
 			"optional": true
 		},
 		"node_modules/undici": {
-			"version": "7.18.2",
-			"resolved": "https://registry.npmjs.org/undici/-/undici-7.18.2.tgz",
-			"integrity": "sha512-y+8YjDFzWdQlSE9N5nzKMT3g4a5UBX1HKowfdXh0uvAnTaqqwqB92Jt4UXBAeKekDs5IaDKyJFR4X1gYVCgXcw==",
+			"version": "7.24.4",
+			"resolved": "https://registry.npmjs.org/undici/-/undici-7.24.4.tgz",
+			"integrity": "sha512-BM/JzwwaRXxrLdElV2Uo6cTLEjhSb3WXboncJamZ15NgUURmvlXvxa6xkwIOILIjPNo9i8ku136ZvWV0Uly8+w==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
@@ -3990,9 +3990,9 @@
 			}
 		},
 		"node_modules/workerd": {
-			"version": "1.20260302.0",
-			"resolved": "https://registry.npmjs.org/workerd/-/workerd-1.20260302.0.tgz",
-			"integrity": "sha512-FhNdC8cenMDllI6bTktFgxP5Bn5ZEnGtofgKipY6pW9jtq708D1DeGI6vGad78KQLBGaDwFy1eThjCoLYgFfog==",
+			"version": "1.20260317.1",
+			"resolved": "https://registry.npmjs.org/workerd/-/workerd-1.20260317.1.tgz",
+			"integrity": "sha512-ZuEq1OdrJBS+NV+L5HMYPCzVn49a2O60slQiiLpG44jqtlOo+S167fWC76kEXteXLLLydeuRrluRel7WdOUa4g==",
 			"dev": true,
 			"hasInstallScript": true,
 			"license": "Apache-2.0",
@@ -4003,28 +4003,28 @@
 				"node": ">=16"
 			},
 			"optionalDependencies": {
-				"@cloudflare/workerd-darwin-64": "1.20260302.0",
-				"@cloudflare/workerd-darwin-arm64": "1.20260302.0",
-				"@cloudflare/workerd-linux-64": "1.20260302.0",
-				"@cloudflare/workerd-linux-arm64": "1.20260302.0",
-				"@cloudflare/workerd-windows-64": "1.20260302.0"
+				"@cloudflare/workerd-darwin-64": "1.20260317.1",
+				"@cloudflare/workerd-darwin-arm64": "1.20260317.1",
+				"@cloudflare/workerd-linux-64": "1.20260317.1",
+				"@cloudflare/workerd-linux-arm64": "1.20260317.1",
+				"@cloudflare/workerd-windows-64": "1.20260317.1"
 			}
 		},
 		"node_modules/wrangler": {
-			"version": "4.68.1",
-			"resolved": "https://registry.npmjs.org/wrangler/-/wrangler-4.68.1.tgz",
-			"integrity": "sha512-G+TI3k/olEGBAVkPtUlhAX/DIbL/190fv3aK+r+45/wPclNEymjxCc35T8QGTDhc2fEMXiw51L5bH9aNsBg+yQ==",
+			"version": "4.75.0",
+			"resolved": "https://registry.npmjs.org/wrangler/-/wrangler-4.75.0.tgz",
+			"integrity": "sha512-Efk1tcnm4eduBYpH1sSjMYydXMnIFPns/qABI3+fsbDrUk5GksNYX8nYGVP4sFygvGPO7kJc36YJKB5ooA7JAg==",
 			"dev": true,
 			"license": "MIT OR Apache-2.0",
 			"dependencies": {
 				"@cloudflare/kv-asset-handler": "0.4.2",
-				"@cloudflare/unenv-preset": "2.14.0",
+				"@cloudflare/unenv-preset": "2.15.0",
 				"blake3-wasm": "2.1.5",
 				"esbuild": "0.27.3",
-				"miniflare": "4.20260302.0",
+				"miniflare": "4.20260317.0",
 				"path-to-regexp": "6.3.0",
 				"unenv": "2.0.0-rc.24",
-				"workerd": "1.20260302.0"
+				"workerd": "1.20260317.1"
 			},
 			"bin": {
 				"wrangler": "bin/wrangler.js",
@@ -4037,7 +4037,7 @@
 				"fsevents": "~2.3.2"
 			},
 			"peerDependencies": {
-				"@cloudflare/workers-types": "^4.20260302.0"
+				"@cloudflare/workers-types": "^4.20260317.1"
 			},
 			"peerDependenciesMeta": {
 				"@cloudflare/workers-types": {
@@ -4046,14 +4046,14 @@
 			}
 		},
 		"node_modules/wrangler/node_modules/@cloudflare/unenv-preset": {
-			"version": "2.14.0",
-			"resolved": "https://registry.npmjs.org/@cloudflare/unenv-preset/-/unenv-preset-2.14.0.tgz",
-			"integrity": "sha512-XKAkWhi1nBdNsSEoNG9nkcbyvfUrSjSf+VYVPfOto3gLTZVc3F4g6RASCMh6IixBKCG2yDgZKQIHGKtjcnLnKg==",
+			"version": "2.15.0",
+			"resolved": "https://registry.npmjs.org/@cloudflare/unenv-preset/-/unenv-preset-2.15.0.tgz",
+			"integrity": "sha512-EGYmJaGZKWl+X8tXxcnx4v2bOZSjQeNI5dWFeXivgX9+YCT69AkzHHwlNbVpqtEUTbew8eQurpyOpeN8fg00nw==",
 			"dev": true,
 			"license": "MIT OR Apache-2.0",
 			"peerDependencies": {
 				"unenv": "2.0.0-rc.24",
-				"workerd": "^1.20260218.0"
+				"workerd": "1.20260301.1 || ~1.20260302.1 || ~1.20260303.1 || ~1.20260304.1 || >1.20260305.0 <2.0.0-0"
 			},
 			"peerDependenciesMeta": {
 				"workerd": {


### PR DESCRIPTION
Resolves Dependabot alerts #158, #159, #161:
- GHSA-f269-vfmq-vjvj: Malicious WebSocket 64-bit length overflow (High)
- GHSA-2mjp-6q6p-2qxm: HTTP Request/Response Smuggling (Moderate)
- GHSA-4992-7rv2-5pvq: CRLF Injection via upgrade option (Moderate)

Updated via npm audit fix:
- undici: 7.18.2 -> 7.24.4
- miniflare: 4.20260302.0 -> 4.20260317.0
- wrangler: updated to 4.75.0