### PR TITLE
fix: use node 22 in deploy workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: '22'
           cache: 'npm'
 
       - name: Install dependencies


### PR DESCRIPTION
### Summary
Fixes deployment failure where Wrangler requires Node.js >= 22 but GitHub Actions was using Node 20.

### Changes
- Updated GitHub Actions deploy workflow to use Node 22.
- No application code changes.

### Why
Deployment failed in "Deploy API Worker" with:
Wrangler requires at least Node.js v22.0.0. You are using v20.20.2.

### Validation
- Workflow config updated in [.github/workflows/deploy.yml](.github/workflows/deploy.yml)
- Branch pushed and ready for PR

### Impact
- CI/deployment-only fix
- Unblocks Wrangler deploy step
- No runtime behavior changes in app code