### PR TITLE
fix: prevent stale cache serving HTML as JS modules

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,10 @@ A modern Vue + Cloudflare D1 app for browsing, syncing, and displaying recipes f
 - Vue frontend with grouped, styled ingredient display
 - Finnish localization for UI
 - Local development with Miniflare/Wrangler
+- User profiles with favorites, shopping lists, and hidden recipes
+- AI-powered recipe assistant
+- Full-text recipe search
+- Admin panel for logs and user management
 
 ## API Overview
 
@@ -290,12 +294,14 @@ Version is stored as git tags (no files tracked) and displayed at the bottom of 
 ```
 koodiapina.net/
 ├── src/                    # Vue frontend source
-│   ├── components/        # Vue components
 │   ├── views/            # Page views
 │   ├── utils/            # Utilities (API client, units parser)
 │   └── styles/           # CSS files
 ├── workers/              # Cloudflare Workers
-│   └── recipes_api/      # Main API worker
+│   ├── recipes_api/      # Main API worker
+│   ├── recipe_sync_ids/  # Recipe ID sync worker
+│   ├── recipe_sync_instructions/ # Instruction sync worker
+│   └── recipe_search_populate/   # Search index worker
 ├── migrations/           # Database migrations
 ├── public/              # Static assets
 └── dist/                # Build output (generated)
@@ -303,14 +309,17 @@ koodiapina.net/
 
 ### Code Structure
 - Frontend: Vue 3, Element Plus, global styles in `src/styles/styles.css`
-- Backend: Cloudflare Workers for sync and API
+- Backend: Cloudflare Workers for sync, search, and API
 - All recipe data is grouped and localized in Finnish
 - To update styles, edit `src/styles/styles.css`
 
 ## Usage
 - Browse recipes with grouped ingredients, pantry items, and steps
 - Click recipe headers to expand/collapse details
-- Only one recipe card is open at a time
+- Add recipes to favorites or hide unwanted ones
+- Manage shopping lists per profile
+- Use AI assistant for recipe-related questions
+- Admin users can view logs and manage profiles
 
 ## Contributing
 Pull requests and issues welcome!

--- a/public/service-worker.js
+++ b/public/service-worker.js
@@ -1,7 +1,5 @@
-const CACHE_NAME = 'koodiapina-ruoka-v5';
+const CACHE_NAME = 'koodiapina-ruoka-v6';
 const urlsToCache = [
-  '/',
-  '/index.html',
   '/manifest.json'
 ];
 
@@ -53,14 +51,13 @@ self.addEventListener('fetch', (event) => {
   event.respondWith(
     fetch(event.request)
       .then((response) => {
-        // Only cache successful GET requests for navigation (HTML)
-        if (event.request.method === 'GET' && 
-            event.request.mode === 'navigate' &&
-            response && response.status === 200) {
-          const responseToCache = response.clone();
-          caches.open(CACHE_NAME).then((cache) => {
-            cache.put(event.request, responseToCache);
+        // Detect stale asset requests that got SPA fallback HTML instead of JS/CSS
+        if (event.request.url.match(/\/assets\/.*\.(js|css)$/) &&
+            response.headers.get('content-type')?.includes('text/html')) {
+          self.clients.matchAll().then(clients => {
+            clients.forEach(client => client.postMessage({ type: 'FORCE_RELOAD' }));
           });
+          return new Response('', { status: 404 });
         }
         return response;
       })


### PR DESCRIPTION
- Remove index.html from service worker cache (no offline benefit since app needs network)
- Bump cache version to v6 to clear old caches on existing users
- Add MIME type guard: if a JS/CSS asset request gets HTML back (SPA fallback for deleted chunks), return 404 and notify clients to reload
- Update README: add missing features, fix project structure, update usage