### PR TITLE
fix: update miniflare and wrangler to resolve undici CVE-2026-13697

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,10 +15,10 @@
 			},
 			"devDependencies": {
 				"@vitejs/plugin-vue": "^5.2.4",
-				"miniflare": "^4.20260625.0",
+				"miniflare": "^4.20260730.0",
 				"vite": "^6.4.3",
 				"vite-plugin-vue-devtools": "^7.7.10",
-				"wrangler": "^4.105.0"
+				"wrangler": "^4.116.0"
 			}
 		},
 		"node_modules/@antfu/utils": {
@@ -513,9 +513,9 @@
 			}
 		},
 		"node_modules/@cloudflare/workerd-darwin-64": {
-			"version": "1.20260722.1",
-			"resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-64/-/workerd-darwin-64-1.20260722.1.tgz",
-			"integrity": "sha512-vZOP8vIS3NwnuaO+gz0FZ7kIGeiO3bZmxV35Ph9zOXKSREhDFlH7wQ7mkCdhW3O4jnXsew+XT7b+DNEI2CcJGQ==",
+			"version": "1.20260730.1",
+			"resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-64/-/workerd-darwin-64-1.20260730.1.tgz",
+			"integrity": "sha512-+MBHmPaiTe2KajryW0T24rZvWFxb41hD3d8anNzQqHzft6vSEb18+sp0znSwxgij7ApPhSM1+vhkNg4f3YMguA==",
 			"cpu": [
 				"x64"
 			],
@@ -530,9 +530,9 @@
 			}
 		},
 		"node_modules/@cloudflare/workerd-darwin-arm64": {
-			"version": "1.20260722.1",
-			"resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-arm64/-/workerd-darwin-arm64-1.20260722.1.tgz",
-			"integrity": "sha512-EmIQymihDq6WNdER4+LF8Qn80yqayBUpJ+tkOO7wmY8pmgfyXjIUFNXotl21AHovTeu2seR7HdVUgeN/BilCWw==",
+			"version": "1.20260730.1",
+			"resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-arm64/-/workerd-darwin-arm64-1.20260730.1.tgz",
+			"integrity": "sha512-SBHKntPkKvNPgaCrTe99xC1CAl8ygJDzlYfK0LbuJ1muKadIw35WnhO0wu894fKBtllsVQdNzDLee+cm0ppLSQ==",
 			"cpu": [
 				"arm64"
 			],
@@ -547,9 +547,9 @@
 			}
 		},
 		"node_modules/@cloudflare/workerd-linux-64": {
-			"version": "1.20260722.1",
-			"resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-64/-/workerd-linux-64-1.20260722.1.tgz",
-			"integrity": "sha512-jvZ3k9fxcnEn04s80CgIYxQfpOyAiz/8qC42DP8EBa9tR27qWyg9wmm31zIobVlrgBZn/+8NfdP73avRGcQOjQ==",
+			"version": "1.20260730.1",
+			"resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-64/-/workerd-linux-64-1.20260730.1.tgz",
+			"integrity": "sha512-ouyPOSMbiKPeSwUJUvxtMcxGAXs2J4aPE4T5ABIYX5ClcQx5j5bbHTmnqOQEY8sAuLTPjH7dY+iB6UI5ISlwwA==",
 			"cpu": [
 				"x64"
 			],
@@ -564,9 +564,9 @@
 			}
 		},
 		"node_modules/@cloudflare/workerd-linux-arm64": {
-			"version": "1.20260722.1",
-			"resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-arm64/-/workerd-linux-arm64-1.20260722.1.tgz",
-			"integrity": "sha512-BOSB55SMNdy+DA5uj2WirgiNanpHGis5PVvXH1wSfvjRKr4JGgWK+EZzxz0RFUo6QjjQQC/NimEzNZ7va7jmKg==",
+			"version": "1.20260730.1",
+			"resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-arm64/-/workerd-linux-arm64-1.20260730.1.tgz",
+			"integrity": "sha512-YQ+Mi78U3TPdgBPtwq+Sm6rJU+Ihl2y0pjYtuuKkdmUbYzL7oLR6Xqq9wljhasnuCFICssDJaqhMep5WizYoEQ==",
 			"cpu": [
 				"arm64"
 			],
@@ -581,9 +581,9 @@
 			}
 		},
 		"node_modules/@cloudflare/workerd-windows-64": {
-			"version": "1.20260722.1",
-			"resolved": "https://registry.npmjs.org/@cloudflare/workerd-windows-64/-/workerd-windows-64-1.20260722.1.tgz",
-			"integrity": "sha512-sYM8YgUpKnRz2xjvdJLX1Ojzoi4MlA4gk8WTTExhGydjYB2UTs5NIbv0ZmpKgMoK9io3ixgmiW56ZnTbcWOdiA==",
+			"version": "1.20260730.1",
+			"resolved": "https://registry.npmjs.org/@cloudflare/workerd-windows-64/-/workerd-windows-64-1.20260730.1.tgz",
+			"integrity": "sha512-27fAN+vUECW1oYVc1KOcHYpkL8COM2Uxtxql7TL595kxbjoqS5yckw7NLz7bTf2pALFCZWjqXDjZGJ/xbG4ZKQ==",
 			"cpu": [
 				"x64"
 			],
@@ -3284,16 +3284,16 @@
 			"license": "MIT"
 		},
 		"node_modules/miniflare": {
-			"version": "4.20260722.0",
-			"resolved": "https://registry.npmjs.org/miniflare/-/miniflare-4.20260722.0.tgz",
-			"integrity": "sha512-LW6ABMhCx/yIEFBLC/DO4yAhdm2T/G7jp7pr5T2kj895+CCIaHZqpMXdW9O6YE48LcYcCJChwWc8aEs1vpbTXw==",
+			"version": "4.20260730.0",
+			"resolved": "https://registry.npmjs.org/miniflare/-/miniflare-4.20260730.0.tgz",
+			"integrity": "sha512-1Z9SB9r/o//80UA02Re3QhtcecSHAyAjf5EcKBfQVlQrCg7Miy79hl2PvtkwFLIaJ5rcrOPdDcRr577okwZPsg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@cspotcode/source-map-support": "0.8.1",
 				"sharp": "0.35.2",
 				"undici": "7.28.0",
-				"workerd": "1.20260722.1",
+				"workerd": "1.20260730.1",
 				"ws": "8.21.0",
 				"youch": "4.1.0-beta.10"
 			},
@@ -4091,9 +4091,9 @@
 			}
 		},
 		"node_modules/workerd": {
-			"version": "1.20260722.1",
-			"resolved": "https://registry.npmjs.org/workerd/-/workerd-1.20260722.1.tgz",
-			"integrity": "sha512-NycKuc1x2onvsRfGGpM093vRlLFU2zHDAM0+APpccfg4+gZxDGCH27RmdDvkeBuoZyYqgLo3oAfF6re4mvC3vQ==",
+			"version": "1.20260730.1",
+			"resolved": "https://registry.npmjs.org/workerd/-/workerd-1.20260730.1.tgz",
+			"integrity": "sha512-zmfNIjwYSWFY5chGBOjWtH3xAE7p97FTC6vR4Ep98290ho6AeAR/NVcBD274YCLEUYzqm8yxdtZlxMybU8a3jA==",
 			"dev": true,
 			"hasInstallScript": true,
 			"license": "Apache-2.0",
@@ -4104,17 +4104,17 @@
 				"node": ">=16"
 			},
 			"optionalDependencies": {
-				"@cloudflare/workerd-darwin-64": "1.20260722.1",
-				"@cloudflare/workerd-darwin-arm64": "1.20260722.1",
-				"@cloudflare/workerd-linux-64": "1.20260722.1",
-				"@cloudflare/workerd-linux-arm64": "1.20260722.1",
-				"@cloudflare/workerd-windows-64": "1.20260722.1"
+				"@cloudflare/workerd-darwin-64": "1.20260730.1",
+				"@cloudflare/workerd-darwin-arm64": "1.20260730.1",
+				"@cloudflare/workerd-linux-64": "1.20260730.1",
+				"@cloudflare/workerd-linux-arm64": "1.20260730.1",
+				"@cloudflare/workerd-windows-64": "1.20260730.1"
 			}
 		},
 		"node_modules/wrangler": {
-			"version": "4.114.0",
-			"resolved": "https://registry.npmjs.org/wrangler/-/wrangler-4.114.0.tgz",
-			"integrity": "sha512-M65P25t5UHA1TIJfgZXDcj+YzVobgKdRguM2QPz0xnxLFuOcuE3ErgllDht0iaho7MS4o0g/Bb4YK2+GT+bibg==",
+			"version": "4.116.0",
+			"resolved": "https://registry.npmjs.org/wrangler/-/wrangler-4.116.0.tgz",
+			"integrity": "sha512-wP1PXxH5KJajfGEjty0NNqyxAirTFvMZpGyB5CRqEIiY0fL/SiCKtIYAJB9HXq0MP0sMXB/i/YSls+WObahAhw==",
 			"dev": true,
 			"license": "MIT OR Apache-2.0",
 			"dependencies": {
@@ -4122,10 +4122,10 @@
 				"@cloudflare/unenv-preset": "2.16.1",
 				"blake3-wasm": "2.1.5",
 				"esbuild": "0.28.1",
-				"miniflare": "4.20260722.0",
+				"miniflare": "4.20260730.0",
 				"path-to-regexp": "6.3.0",
 				"unenv": "2.0.0-rc.24",
-				"workerd": "1.20260722.1"
+				"workerd": "1.20260730.1"
 			},
 			"bin": {
 				"cf-wrangler": "bin/cf-wrangler.js",
@@ -4139,7 +4139,7 @@
 				"fsevents": "2.3.3"
 			},
 			"peerDependencies": {
-				"@cloudflare/workers-types": "^5.20260722.1"
+				"@cloudflare/workers-types": "^5.20260730.1"
 			},
 			"peerDependenciesMeta": {
 				"@cloudflare/workers-types": {

--- a/package.json
+++ b/package.json
@@ -17,10 +17,10 @@
 	},
 	"devDependencies": {
 		"@vitejs/plugin-vue": "^5.2.4",
-		"miniflare": "^4.20260625.0",
+		"miniflare": "^4.20260730.0",
 		"vite": "^6.4.3",
 		"vite-plugin-vue-devtools": "^7.7.10",
-		"wrangler": "^4.105.0"
+		"wrangler": "^4.116.0"
 	},
 	"overrides": {
 		"postcss": "^8.5.10",


### PR DESCRIPTION
Update miniflare 4.20260625.0 -> 4.20260730.0 and wrangler 4.105.0 -> 4.116.0. The undici override already resolves to 7.29.0 (patched version) but this update ensures both deps share the same miniflare version and triggers Dependabot to re-evaluate the alert (GHSA-4cwx-7wf7-3272).